### PR TITLE
Some basic sanitation in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,15 +11,15 @@ function deleteOld {
 	if [ $( grep "SUDO - shout at bash" "$RCFILE" | wc -l ) -eq 0 ]; then
 	       	echo "No current installation found"
 		return
-        fi	       
-	
+        fi
+
 	cp "$RCFILE" "$RCFILE.old"
 
-	# Check for old versions	
+	# Check for old versions
 	if [ $( grep "end SUDO" "$RCFILE" | wc -l ) -eq 0 ]; then
 		compatDelete
 		exit 0
-	fi	
+	fi
 
 	echo "Searching for recent installation..."
 
@@ -38,7 +38,7 @@ function deleteOld {
 	    }
 	}
 	f==0{print > rcfile}
-	' "$RCFILE" 
+	' "$RCFILE"
 }
 
 deleteOld
@@ -47,7 +47,7 @@ echo "Installing..."
 
 cat ./SUDO >> "$RCFILE"
 echo '
-Now run:      source ' $RCFILE ' 
+Now run:      source ' $RCFILE '
 '
 
 exit 0

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-RCFILE=~/.bashrc
+RCFILE=$HOME/.bashrc
 
 function compatDelete {
 	echo "You have an older version of SUDO present. Please remove it from $RCFILE to be able to update to the new version."


### PR DESCRIPTION
Since '~' is an alias for '$HOME', I feel as if it would be a cleaner approach for pointing at the .bashrc file in the users home directory from within the install.sh file. Also, some whitespaces and whitetabs were removed from said file.